### PR TITLE
Add BARCON website template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# ChatGPT
+# BARCON – Barkanov Construction Website
+
+This repository contains a responsive, animated website template for the BARCON architectural bureau. It includes:
+
+- Sections for Home, Services, Portfolio and Contacts
+- Interactive cards with modal details
+- Telegram contact links
+- Russian and English languages
+- Three themes: default, black & white and pastel
+- Responsive navigation with burger menu on mobile
+
+To view the site locally, open `index.html` in a browser.
+
+## Development
+
+Install dependencies and run the test script:
+
+```bash
+npm install
+npm test
+```
+
+(No additional tests are defined.)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,248 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #222222;
+  --accent: #c7923e;
+  --transition: all 0.3s ease;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  transition: var(--transition);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: var(--bg-color);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.logo {
+  font-weight: bold;
+  font-size: 1.5rem;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-links li a {
+  text-decoration: none;
+  color: var(--text-color);
+  position: relative;
+  padding: 0.25rem 0;
+}
+
+.nav-links li a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: width 0.3s;
+}
+
+.nav-links li a:hover::after {
+  width: 100%;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.burger {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.burger span {
+  width: 25px;
+  height: 3px;
+  background: var(--text-color);
+  margin: 4px 0;
+  transition: var(--transition);
+}
+
+.hero {
+  background: url("https://source.unsplash.com/1600x900?architecture,modern")
+    center/cover no-repeat;
+  color: #fff;
+  text-align: center;
+  padding: 6rem 1rem;
+}
+
+.section {
+  padding: 4rem 1rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transform: translateY(0);
+  transition: var(--transition);
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.card img {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+}
+
+.btn {
+  background: var(--accent);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.btn:hover {
+  background: #a36f2d;
+}
+
+.telegram-links {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+}
+
+.modal.show {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.modal-content {
+  background: var(--bg-color);
+  color: var(--text-color);
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80%;
+  overflow-y: auto;
+  position: relative;
+}
+
+.modal-content img {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+/* Themes */
+body.theme-default {
+  --bg-color: #ffffff;
+  --text-color: #222222;
+  --accent: #c7923e;
+}
+
+body.theme-bw {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --accent: #000000;
+  filter: grayscale(100%);
+}
+
+body.theme-pastel {
+  --bg-color: #f6f1ee;
+  --text-color: #5d5d5d;
+  --accent: #b0a1ba;
+}
+
+/* Animations */
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.section,
+.hero {
+  animation: fadeUp 0.6s ease both;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    right: 10px;
+    background: var(--bg-color);
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  .nav-links.show {
+    display: flex;
+  }
+
+  .burger {
+    display: flex;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BARCON – Barkanov Construction</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="theme-default">
+    <header>
+      <nav class="navbar">
+        <div class="logo" data-i18n="logo">BARCON</div>
+        <ul class="nav-links" id="nav-links">
+          <li><a href="#home" data-i18n="nav.home">Главная</a></li>
+          <li><a href="#services" data-i18n="nav.services">Услуги</a></li>
+          <li><a href="#portfolio" data-i18n="nav.portfolio">Портфолио</a></li>
+          <li><a href="#contacts" data-i18n="nav.contacts">Контакты</a></li>
+        </ul>
+        <div class="nav-actions">
+          <select id="language-switch" aria-label="language switch">
+            <option value="ru">RU</option>
+            <option value="en">EN</option>
+          </select>
+          <select id="theme-switch" aria-label="theme switch">
+            <option value="default" data-i18n="theme.default">Основная</option>
+            <option value="bw" data-i18n="theme.bw">Ч/Б</option>
+            <option value="pastel" data-i18n="theme.pastel">Пастель</option>
+          </select>
+          <div class="burger" id="burger">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section id="home" class="hero">
+        <h1 data-i18n="hero.title">BARCON — Barkanov Construction</h1>
+        <p data-i18n="hero.subtitle">Архитектурное бюро будущего</p>
+        <a
+          class="btn contact-btn"
+          href="https://t.me/barcon_bot"
+          target="_blank"
+          data-i18n="buttons.contact"
+          >Связаться</a
+        >
+      </section>
+
+      <section id="services" class="section">
+        <h2 data-i18n="services.title">Услуги</h2>
+        <div class="cards">
+          <div class="card" data-service="architecture">
+            <img
+              src="https://source.unsplash.com/400x300?architecture"
+              alt="architecture"
+            />
+            <h3 data-i18n="services.architecture.title">
+              Архитектурные решения
+            </h3>
+            <p data-i18n="services.architecture.brief">
+              Современные и эргономичные здания
+            </p>
+          </div>
+          <div class="card" data-service="structure">
+            <img
+              src="https://source.unsplash.com/400x300?construction"
+              alt="construction"
+            />
+            <h3 data-i18n="services.structure.title">Конструктивные решения</h3>
+            <p data-i18n="services.structure.brief">Надежные конструкции</p>
+          </div>
+          <div class="card" data-service="visualization">
+            <img
+              src="https://source.unsplash.com/400x300?render"
+              alt="render"
+            />
+            <h3 data-i18n="services.visualization.title">
+              Визуализация экстерьера
+            </h3>
+            <p data-i18n="services.visualization.brief">
+              Фотореалистичные изображения
+            </p>
+          </div>
+          <div class="card" data-service="measurement">
+            <img
+              src="https://source.unsplash.com/400x300?blueprint"
+              alt="measurement"
+            />
+            <h3 data-i18n="services.measurement.title">Обмерные работы</h3>
+            <p data-i18n="services.measurement.brief">Точные замеры объектов</p>
+          </div>
+          <div class="card" data-service="supervision">
+            <img
+              src="https://source.unsplash.com/400x300?supervision"
+              alt="supervision"
+            />
+            <h3 data-i18n="services.supervision.title">Авторский надзор</h3>
+            <p data-i18n="services.supervision.brief">
+              Контроль реализации проекта
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="portfolio" class="section">
+        <h2 data-i18n="portfolio.title">Портфолио</h2>
+        <div class="cards">
+          <div class="card" data-portfolio="residential">
+            <img
+              src="https://source.unsplash.com/400x300?house"
+              alt="residential"
+            />
+            <h3 data-i18n="portfolio.residential.title">Жилые объекты</h3>
+          </div>
+          <div class="card" data-portfolio="commercial">
+            <img
+              src="https://source.unsplash.com/400x300?office"
+              alt="commercial"
+            />
+            <h3 data-i18n="portfolio.commercial.title">Коммерческие объекты</h3>
+          </div>
+        </div>
+      </section>
+
+      <section id="contacts" class="section">
+        <h2 data-i18n="contacts.title">Контакты</h2>
+        <p data-i18n="contacts.slogan">Свяжитесь с нами через Telegram</p>
+        <a
+          class="btn contact-btn"
+          href="https://t.me/barcon_bot"
+          target="_blank"
+          data-i18n="buttons.contact"
+          >Связаться</a
+        >
+        <div class="telegram-links">
+          <a
+            href="https://t.me/barcon_bot"
+            target="_blank"
+            data-i18n="contacts.bot"
+            >Telegram бот</a
+          >
+          <a
+            href="https://t.me/barcon_channel"
+            target="_blank"
+            data-i18n="contacts.channel"
+            >Telegram канал</a
+          >
+        </div>
+      </section>
+    </main>
+
+    <div id="modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close" id="modal-close">&times;</span>
+        <div class="modal-body"></div>
+      </div>
+    </div>
+
+    <script src="js/script.js"></script>
+  </body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,220 @@
+const translations = {
+  ru: {
+    logo: "BARCON",
+    nav: {
+      home: "Главная",
+      services: "Услуги",
+      portfolio: "Портфолио",
+      contacts: "Контакты",
+    },
+    theme: { default: "Основная", bw: "Ч/Б", pastel: "Пастель" },
+    hero: {
+      title: "BARCON — Barkanov Construction",
+      subtitle: "Архитектурное бюро будущего",
+    },
+    buttons: { contact: "Связаться" },
+    services: {
+      title: "Услуги",
+      architecture: {
+        title: "Архитектурные решения",
+        brief: "Современные и эргономичные здания",
+        description:
+          "Разработка концепции, планировочных решений и фасадов с учётом ваших пожеланий.",
+        example: "https://source.unsplash.com/800x600?modern-building",
+        price: "от 1500$/м²",
+      },
+      structure: {
+        title: "Конструктивные решения",
+        brief: "Надежные конструкции",
+        description:
+          "Проектирование несущих элементов здания и расчёт нагрузок.",
+        example: "https://source.unsplash.com/800x600?structure",
+        price: "от 1200$/м²",
+      },
+      visualization: {
+        title: "Визуализация экстерьера",
+        brief: "Фотореалистичные изображения",
+        description:
+          "3D-визуализации проекта для представления конечного результата.",
+        example: "https://source.unsplash.com/800x600?3d,render",
+        price: "от 20$/м²",
+      },
+      measurement: {
+        title: "Обмерные работы",
+        brief: "Точные замеры объектов",
+        description:
+          "Выезд на объект и создание точных чертежей существующих зданий.",
+        example: "https://source.unsplash.com/800x600?surveying",
+        price: "от 5$/м²",
+      },
+      supervision: {
+        title: "Авторский надзор",
+        brief: "Контроль реализации проекта",
+        description:
+          "Сопровождение строительства и контроль соответствия проекту.",
+        example: "https://source.unsplash.com/800x600?site,supervision",
+        price: "индивидуально",
+      },
+    },
+    portfolio: {
+      title: "Портфолио",
+      residential: { title: "Жилые объекты" },
+      commercial: { title: "Коммерческие объекты" },
+    },
+    contacts: {
+      title: "Контакты",
+      slogan: "Свяжитесь с нами через Telegram",
+      bot: "Telegram бот",
+      channel: "Telegram канал",
+    },
+  },
+  en: {
+    logo: "BARCON",
+    nav: {
+      home: "Home",
+      services: "Services",
+      portfolio: "Portfolio",
+      contacts: "Contacts",
+    },
+    theme: { default: "Default", bw: "B/W", pastel: "Pastel" },
+    hero: {
+      title: "BARCON — Barkanov Construction",
+      subtitle: "Architecture bureau of the future",
+    },
+    buttons: { contact: "Contact us" },
+    services: {
+      title: "Services",
+      architecture: {
+        title: "Architectural solutions",
+        brief: "Modern and ergonomic buildings",
+        description:
+          "Development of concept, layout and facades tailored to your wishes.",
+        example: "https://source.unsplash.com/800x600?modern-building",
+        price: "from $1500/m²",
+      },
+      structure: {
+        title: "Structural design",
+        brief: "Reliable constructions",
+        description: "Design of load-bearing elements and load calculations.",
+        example: "https://source.unsplash.com/800x600?structure",
+        price: "from $1200/m²",
+      },
+      visualization: {
+        title: "Exterior visualization",
+        brief: "Photorealistic images",
+        description: "3D renderings to present the final result.",
+        example: "https://source.unsplash.com/800x600?3d,render",
+        price: "from $20/m²",
+      },
+      measurement: {
+        title: "Measurement works",
+        brief: "Accurate object measurements",
+        description:
+          "Site visit and creation of precise drawings of existing buildings.",
+        example: "https://source.unsplash.com/800x600?surveying",
+        price: "from $5/m²",
+      },
+      supervision: {
+        title: "Author supervision",
+        brief: "Project implementation control",
+        description: "Construction support and compliance control.",
+        example: "https://source.unsplash.com/800x600?site,supervision",
+        price: "custom",
+      },
+    },
+    portfolio: {
+      title: "Portfolio",
+      residential: { title: "Residential projects" },
+      commercial: { title: "Commercial projects" },
+    },
+    contacts: {
+      title: "Contacts",
+      slogan: "Contact us via Telegram",
+      bot: "Telegram bot",
+      channel: "Telegram channel",
+    },
+  },
+};
+
+let currentLang = "ru";
+
+function setLanguage(lang) {
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const keys = el.dataset.i18n.split(".");
+    let value = translations[lang];
+    keys.forEach((k) => (value = value[k]));
+    if (value) el.textContent = value;
+  });
+}
+
+const languageSwitch = document.getElementById("language-switch");
+languageSwitch.addEventListener("change", (e) => setLanguage(e.target.value));
+setLanguage("ru");
+
+const themeSwitch = document.getElementById("theme-switch");
+themeSwitch.addEventListener("change", (e) => {
+  document.body.className = `theme-${e.target.value}`;
+});
+
+const burger = document.getElementById("burger");
+const navLinks = document.getElementById("nav-links");
+burger.addEventListener("click", () => {
+  navLinks.classList.toggle("show");
+});
+
+const modal = document.getElementById("modal");
+const modalBody = modal.querySelector(".modal-body");
+const modalClose = document.getElementById("modal-close");
+
+function openModal(html) {
+  modalBody.innerHTML = html;
+  modal.classList.add("show");
+}
+
+function closeModal() {
+  modal.classList.remove("show");
+}
+
+modalClose.addEventListener("click", closeModal);
+modal.addEventListener("click", (e) => {
+  if (e.target === modal) closeModal();
+});
+
+function serviceHTML(key) {
+  const data = translations[currentLang].services[key];
+  return `<h3>${data.title}</h3><p>${data.description}</p><img src="${data.example}" alt="${data.title}"><p>${data.price}</p><a class="btn contact-btn" href="https://t.me/barcon_bot" target="_blank">${translations[currentLang].buttons.contact}</a>`;
+}
+
+document.querySelectorAll("[data-service]").forEach((card) => {
+  card.addEventListener("click", () => {
+    openModal(serviceHTML(card.dataset.service));
+  });
+});
+
+const portfolioDetails = {
+  residential: [
+    "https://source.unsplash.com/800x600?house,1",
+    "https://source.unsplash.com/800x600?house,2",
+    "https://source.unsplash.com/800x600?house,3",
+  ],
+  commercial: [
+    "https://source.unsplash.com/800x600?office,1",
+    "https://source.unsplash.com/800x600?office,2",
+    "https://source.unsplash.com/800x600?office,3",
+  ],
+};
+
+function portfolioHTML(key) {
+  const images = portfolioDetails[key]
+    .map((src) => `<img src="${src}" alt="${key}">`)
+    .join("");
+  return `<h3>${translations[currentLang].portfolio[key].title}</h3>${images}`;
+}
+
+document.querySelectorAll("[data-portfolio]").forEach((card) => {
+  card.addEventListener("click", () => {
+    openModal(portfolioHTML(card.dataset.portfolio));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chatgpt",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- Build multilingual, themed BARCON landing site with services, portfolio, and contact sections
- Add responsive styling with animated cards and burger navigation
- Include JavaScript for language, theme switching and modal content

## Testing
- `npm test`
- `node --check js/script.js`
- `npx prettier --write index.html css/styles.css js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689a63827434832d9a7a0c288da13629